### PR TITLE
Adding System.Collections.Immutable into the mix

### DIFF
--- a/FSharpLibrary/FSharpLibrary.fsproj
+++ b/FSharpLibrary/FSharpLibrary.fsproj
@@ -9,4 +9,8 @@
     <Compile Include="Library.fs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/Tests/Tests.fsproj
+++ b/Tests/Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
@@ -13,12 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2-beta2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.5.0" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "7.0.100"
+    "version": "7.0.200-preview.22628.1"
   }
 }


### PR DESCRIPTION
Hi Florian,
We are also hit by the "Could not load type 'System.Runtime.CompilerServices.IsReadOnlyAttribute' from assembly System.Collections.Immutable ..." when trying to upgrade to .NET 7.

I observed, that the System.Runtime.CompilerServices.IsReadOnlyAttribute is emitted to F# struct only when System.Collections.Immutable package is referenced in the project.

I have tried to build with the latest preview 7.0.200-preview.22628.1 as well, same result. But I am not sure, if the fix is already included there.
You've said [I was able to compile my [repro] with the local compiler and the test now passes.](https://github.com/dotnet/fsharp/pull/14276#issue-1442050951)

Could you try it again with this PR?

Cheers sam